### PR TITLE
fix? : Audio settings not saving

### DIFF
--- a/Source/KeepPushing/Private/Sound/SoundManager.cpp
+++ b/Source/KeepPushing/Private/Sound/SoundManager.cpp
@@ -46,6 +46,9 @@ void USoundManager::Initialize(FSubsystemCollectionBase& Collection)
 	if (Save)
 	{
 		Volume = Save->MasterVolume;
+	} else
+	{
+		SaveVolumeToDisk();
 	}
 
 	SetMasterVolume(Volume);


### PR DESCRIPTION
Tried a fix for audio settings not saving properly ad not being able to be changed when the game was packaged